### PR TITLE
📝 Add a swagger for API documentations (EPI-264)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/config": "^3.3.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^8.1.0",
         "@prisma/client": "^6.0.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
@@ -2338,6 +2339,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.8",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.8.tgz",
@@ -2480,6 +2487,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
+      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.4.12",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.12.tgz",
@@ -2524,6 +2551,39 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-8.1.0.tgz",
+      "integrity": "sha512-8hzH+r/31XshzXHC9vww4T0xjDAxMzvOaT1xAOvvY1LtXTWyNRCUP2iQsCYJOnnMrR+vydWjvRZiuB3hdvaHxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.6",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.3.0",
+        "swagger-ui-dist": "5.18.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.12",
@@ -2774,6 +2834,13 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3804,7 +3871,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -7691,7 +7757,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9988,6 +10053,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
+      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "open-api": "nest start -- openapi=1"
   },
   "dependencies": {
     "@firebase/auth": "^1.8.1",
@@ -25,6 +26,7 @@
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^8.1.0",
     "@prisma/client": "^6.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,11 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiResponse, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Test')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @ApiResponse({ status: 200, description: 'Returns Hello World!', schema: { example: 'Hello World!' }})
   getHello(): string {
     return this.appService.getHello();
   }

--- a/src/dtos/auth/auth.dto.ts
+++ b/src/dtos/auth/auth.dto.ts
@@ -1,19 +1,36 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class AuthDto {
+    @ApiProperty({
+        description: 'Email address of the user',
+        example: 'usermail@site.com'
+    })
     @IsEmail()
     email: string;
 
+    @ApiProperty({
+        description: 'Password of the user',
+        example: 'password'
+    })
     @IsString()
     @IsNotEmpty()
     password: string;
 }
 
 export class RegisterDto extends AuthDto {
+    @ApiProperty({
+        description: 'Name of the user',
+        example: 'John'
+    })
     @IsString()
     @IsNotEmpty()
     name: string;
 
+    @ApiProperty({
+        description: 'Surname of the user',
+        example: 'Doe'
+    })
     @IsString()
     @IsNotEmpty()
     surname: string;

--- a/src/dtos/user/user.dto.ts
+++ b/src/dtos/user/user.dto.ts
@@ -1,13 +1,26 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UserDto {
+    @ApiProperty({
+        description: 'The email of the User',
+        example: 'usermail@site.com'
+    })
     @IsEmail()
     email: string;
 
+    @ApiProperty({
+        description: 'The name of the User',
+        example: 'John'
+    })
     @IsString()
     @IsNotEmpty()
     name: string;
 
+    @ApiProperty({
+        description: 'The surname of the User',
+        example: 'Doe'
+    })
     @IsString()
     @IsNotEmpty()
     surname: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ async function bootstrap() {
       .setTitle('Wytness API')
       .setDescription('The Wytness API description')
       .setVersion('1.0')
+      .addServer('http://localhost:3000', 'Localhost server')
       .build();
     const document = SwaggerModule.createDocument(app, config);
     SwaggerModule.setup('api', app, document);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,40 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const isOpenApiEnable = (argv: string[]): boolean => {
+  for (const arg of argv) {
+    if (arg.startsWith('openapi=')) {
+      return arg[arg.length - 1] === '1';
+    }
+  }
+  return false;
+};
+
+const writeSwaggerJson = async (document: any) => {
+  const jsonPath = path.join(__dirname, 'swagger.json');
+  fs.writeFileSync(jsonPath, JSON.stringify(document, null, 2));
+  console.log(`Swagger JSON written to ${jsonPath}`);
+}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { cors: true });
+
+  if (isOpenApiEnable(process.argv)) {
+    console.log('OpenAPI enabled');
+    const config = new DocumentBuilder()
+      .setTitle('Wytness API')
+      .setDescription('The Wytness API description')
+      .setVersion('1.0')
+      .build();
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api', app, document);
+
+    await writeSwaggerJson(document);
+  }
 
   app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true}));
   await app.listen(process.env.PORT ?? 3000);

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,12 +1,20 @@
 import { Controller, Post, Body, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { AuthDto, RegisterDto } from '../../dtos/auth/auth.dto';
+import { ApiResponse, ApiTags, ApiBody, ApiProperty } from '@nestjs/swagger';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
     constructor(private readonly authService: AuthService) {}
 
     @Post('login')
+    @ApiBody({
+        description: 'Email and password of the user (login)',
+        type: AuthDto
+    })
+    @ApiResponse({ status: 200, description: 'Login successful', schema: { example: { token: 'string' } } })
+    @ApiResponse({ status: 401, description: 'Unauthorized', schema: { example: { statusCode: 401, error: 'string' } } })
     async login(@Body() body: AuthDto): Promise<{token: string}> {
         const token: {token: string} | {error: string} = await this.authService.login(body.email, body.password);
         if ('token' in token) {
@@ -16,6 +24,12 @@ export class AuthController {
     }
 
     @Post('register')
+    @ApiBody({
+        description: 'Email, password, name and surname of the user (registration)',
+        type: RegisterDto
+    })
+    @ApiResponse({ status: 200, description: 'Registration successful', schema: { example: { token: 'string' } } })
+    @ApiResponse({ status: 401, description: 'Unauthorized', schema: { example: { statusCode: 401, error: 'string' } } })
     async register(@Body() body: RegisterDto): Promise<{token: string}> {
         const token: {token: string} | {error: string} = await this.authService.register(body.email, body.password, body.name, body.surname);
         if ('token' in token) {


### PR DESCRIPTION
This pull request introduces OpenAPI (Swagger) support to the project by adding necessary configurations and decorators to various files. The most important changes include the addition of Swagger decorators to controllers and DTOs, as well as the setup of Swagger in the main application file.

### OpenAPI (Swagger) Integration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R29): Added `@nestjs/swagger` dependency and a new script `open-api` to start the application with OpenAPI enabled.

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR4-R38): Introduced functions to enable OpenAPI based on command-line arguments, configured Swagger with `DocumentBuilder`, and wrote Swagger JSON to a file.

### Controller Enhancements:

* [`src/app.controller.ts`](diffhunk://#diff-ef0ff0ca9442bda67ad0810654d636991173ecd7c1abcd6da09288b8815759ffR3-R11): Added `@ApiTags` and `@ApiResponse` decorators to the `AppController` to document the API.

* [`src/modules/auth/auth.controller.ts`](diffhunk://#diff-42e3b730ea71ff2e054bc7a00e3b596ba41fa3eeff2af66e2b9358f404f2b625R4-R17): Added `@ApiTags`, `@ApiBody`, and `@ApiResponse` decorators to the `AuthController` to document login and registration endpoints. [[1]](diffhunk://#diff-42e3b730ea71ff2e054bc7a00e3b596ba41fa3eeff2af66e2b9358f404f2b625R4-R17) [[2]](diffhunk://#diff-42e3b730ea71ff2e054bc7a00e3b596ba41fa3eeff2af66e2b9358f404f2b625R27-R32)

### DTO Enhancements:

* [`src/dtos/auth/auth.dto.ts`](diffhunk://#diff-78a72c00849ca2191e36e323bef33b470db4df6a143088bfedc1547319373683R2-R33): Added `@ApiProperty` decorators to the `AuthDto` and `RegisterDto` classes to document their properties.

* [`src/dtos/user/user.dto.ts`](diffhunk://#diff-e7e08f6f58567016392468a54dd08a0aeabd8b499159c77da73e26cc4f96ffe1R2-R23): Added `@ApiProperty` decorators to the `UserDto` class to document its properties.