### PR TITLE
🧹  Update workflow node dto to only contain node id

### DIFF
--- a/src/modules/workflows/workflows.service.ts
+++ b/src/modules/workflows/workflows.service.ts
@@ -685,10 +685,6 @@ export class WorkflowsService implements OnModuleInit {
       id: node.id,
       config: node.config,
       node: {
-        name: node.node.name,
-        description: node.node.description,
-        labels: node.node.labels,
-        type: node.node.type,
         id: node.node.id,
       },
       next: (node.next ? node.next : []).map((next) => {

--- a/src/modules/workflows/workflows.service.ts
+++ b/src/modules/workflows/workflows.service.ts
@@ -684,9 +684,7 @@ export class WorkflowsService implements OnModuleInit {
     return {
       id: node.id,
       config: node.config,
-      node: {
-        id: node.node.id,
-      },
+      nodeId: node.node.id,
       next: (node.next ? node.next : []).map((next) => {
         return {
           label: next.label,


### PR DESCRIPTION
This pull request includes a small change to the `WorkflowsService` class in the `src/modules/workflows/workflows.service.ts` file. The change involves removing redundant properties from the `node` object.

Changes to `WorkflowsService`:

* Removed `name`, `description`, `labels`, and `type` properties from the `node` object in the `WorkflowsService` class.