### PR TITLE
🙅‍♂️ Add route to disconnect a service

### DIFF
--- a/src/modules/services/services.controller.ts
+++ b/src/modules/services/services.controller.ts
@@ -112,6 +112,48 @@ export class ServicesController {
   }
 
   @Private()
+  @Post('/:serviceName/disconnect')
+  @ApiParam({
+    name: 'serviceName',
+    description: 'Name of the service',
+    type: 'string',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Service disconnected',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Service not found',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Service does not use OAuth or code auth',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal server error',
+  })
+  @ApiBearerAuth('token')
+  async disconnect(@Param('serviceName') serviceName: string) {
+    const service = this._servicesService.getServiceByName(serviceName);
+    if (!service) {
+      throw new NotFoundException('Service not found');
+    }
+    if (service.serviceMetadata.useAuth === undefined) {
+      throw new BadRequestException('Service does not use OAuth or code auth');
+    }
+
+    const success = await this._servicesService.disconnectService(
+      this._authContext.user.id,
+      serviceName,
+    );
+    if (!success) {
+      throw new InternalServerErrorException('Failed to disconnect service');
+    }
+    return;
+  }
+
+  @Private()
   @Post('/:serviceName/connect/form')
   @ApiParam({
     name: 'serviceName',

--- a/src/modules/services/services.service.ts
+++ b/src/modules/services/services.service.ts
@@ -142,4 +142,19 @@ export class ServicesService {
       service.nodes.some((node) => node.id === nodeId),
     );
   }
+
+  public async disconnectService(
+    userId: number,
+    serviceName: string,
+  ): Promise<boolean> {
+    const service = this.getServiceByName(serviceName);
+    if (!service) {
+      throw new Error('Service not found');
+    }
+    if (service.serviceMetadata.useAuth) {
+      const withAuth = service as ServiceWithAuth;
+      return await withAuth.disconnectUser(userId);
+    }
+    return false;
+  }
 }

--- a/src/types/services/service.type.ts
+++ b/src/types/services/service.type.ts
@@ -196,6 +196,17 @@ export abstract class ServiceWithAuth extends Service {
   protected _serviceUserRepository: Repository<ServiceUser>;
 
   public abstract isUserConnected(userId: number): Promise<boolean>;
+
+  public async disconnectUser(userId: number): Promise<boolean> {
+    return !!(await this._serviceUserRepository.delete({
+      user: {
+        id: userId,
+      },
+      service: {
+        name: this.getName(),
+      },
+    }));
+  }
 }
 
 @Injectable()


### PR DESCRIPTION
This pull request introduces a new feature to allow users to disconnect services. The main changes include adding a new endpoint in the `ServicesController`, implementing the corresponding logic in the `ServicesService`, and adding a method to handle the disconnection in the `ServiceWithAuth` class.

New endpoint in `ServicesController`:

* [`src/modules/services/services.controller.ts`](diffhunk://#diff-38a61847689f2ac1c83d3d5e439b908d716539089f5b8fe36f1c9bc14a3bcc71R114-R155): Added a new `disconnect` method with appropriate decorators for handling the disconnection of services. This includes validation for service existence and authentication type, and error handling for various scenarios.

Service disconnection logic in `ServicesService`:

* [`src/modules/services/services.service.ts`](diffhunk://#diff-d733b4fc1040a3f634cdef9f7976df522674db4e7f04ca418eaaa072759704b7R145-R159): Implemented the `disconnectService` method to handle the disconnection logic, including checking for service existence and whether the service uses authentication.

Disconnection method in `ServiceWithAuth`:

* [`src/types/services/service.type.ts`](diffhunk://#diff-9ea89e35ce8ed775669472466a3135051e7d0daaf8866b673a9db3ccb58924bdR199-R209): Added the `disconnectUser` method to the `ServiceWithAuth` class to delete the user-service association from the repository.