### PR TITLE
📏 Fix logo resizing

### DIFF
--- a/src/modules/services/services.controller.ts
+++ b/src/modules/services/services.controller.ts
@@ -305,9 +305,15 @@ export class ServicesController {
     }
     if (width) {
       content = content.replace(/width="(\d+)"/, `width="${width}"`);
+      if (!content.includes('width')) {
+        content = content.replace('<svg', `<svg width="${width}"`);
+      }
     }
     if (height) {
       content = content.replace(/height="(\d+)"/, `height="${height}"`);
+      if (!content.includes('height')) {
+        content = content.replace('<svg', `<svg height="${height}"`);
+      }
     }
     response.appendHeader('Content-Type', 'image/svg+xml');
     response.send(content);


### PR DESCRIPTION
This pull request includes a small change to the `ServicesController` class in the `src/modules/services/services.controller.ts` file. The change ensures that the `width` and `height` attributes are added to the SVG element if they are not already present.

* [`src/modules/services/services.controller.ts`](diffhunk://#diff-38a61847689f2ac1c83d3d5e439b908d716539089f5b8fe36f1c9bc14a3bcc71R308-R316): Added checks to insert `width` and `height` attributes into the `<svg>` tag if they are not already included in the content.