### PR TITLE
✨ Disable db if no env

### DIFF
--- a/src/providers/database/database.providers.ts
+++ b/src/providers/database/database.providers.ts
@@ -17,6 +17,9 @@ export const databaseProviders = [
     provide: 'DATA_SOURCE',
     inject: [ConfigService],
     useFactory: (configService: ConfigService) => {
+      if (!configService.get<string>('DB_HOST')) {
+        return null;
+      }
       const dataSource = new DataSource({
         type: 'postgres',
         host: configService.get<string>('DB_HOST'),

--- a/src/providers/database/providers/permission.providers.ts
+++ b/src/providers/database/providers/permission.providers.ts
@@ -4,7 +4,12 @@ import { Policy, Rule } from '../../../types/permissions';
 export const policiesProviders = [
   {
     provide: 'POLICIES_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Policy),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(Policy);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -12,7 +17,12 @@ export const policiesProviders = [
 export const rulesProviders = [
   {
     provide: 'RULES_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Rule),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(Rule);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];

--- a/src/providers/database/providers/service.providers.ts
+++ b/src/providers/database/providers/service.providers.ts
@@ -4,7 +4,12 @@ import { Service, Node, Code, ServiceUser } from '../../../types/services';
 export const serviceProviders = [
   {
     provide: 'SERVICE_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Service),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(Service);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -12,7 +17,12 @@ export const serviceProviders = [
 export const serviceNodeProviders = [
   {
     provide: 'SERVICE_NODE_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Node),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(Node);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -20,7 +30,12 @@ export const serviceNodeProviders = [
 export const codeProviders = [
   {
     provide: 'CODE_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Code),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(Code);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -28,8 +43,12 @@ export const codeProviders = [
 export const serviceUserProviders = [
   {
     provide: 'SERVICE_USER_REPOSITORY',
-    useFactory: (dataSource: DataSource) =>
-      dataSource.getRepository(ServiceUser),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(ServiceUser);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];

--- a/src/providers/database/providers/user.providers.ts
+++ b/src/providers/database/providers/user.providers.ts
@@ -4,7 +4,12 @@ import { User } from '../../../types/user';
 export const userProviders = [
   {
     provide: 'USER_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(User),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(User);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];

--- a/src/providers/database/providers/webhook.providers.ts
+++ b/src/providers/database/providers/webhook.providers.ts
@@ -4,7 +4,12 @@ import { Webhook } from '../../../types/webhook/webhook.type';
 export const webhookProviders = [
   {
     provide: 'WEBHOOK_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Webhook),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(Webhook);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];

--- a/src/providers/database/providers/workflow.providers.ts
+++ b/src/providers/database/providers/workflow.providers.ts
@@ -10,7 +10,12 @@ import {
 export const workflowProviders = [
   {
     provide: 'WORKFLOW_REPOSITORY',
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Workflow),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(Workflow);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -18,8 +23,12 @@ export const workflowProviders = [
 export const workflowNodeProviders = [
   {
     provide: 'WORKFLOW_NODE_REPOSITORY',
-    useFactory: (dataSource: DataSource) =>
-      dataSource.getRepository(WorkflowNode),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(WorkflowNode);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -27,8 +36,12 @@ export const workflowNodeProviders = [
 export const workflowNodeNextProviders = [
   {
     provide: 'WORKFLOW_NODE_NEXT_REPOSITORY',
-    useFactory: (dataSource: DataSource) =>
-      dataSource.getRepository(WorkflowNodeNext),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(WorkflowNodeNext);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -36,8 +49,12 @@ export const workflowNodeNextProviders = [
 export const workflowExecutionProviders = [
   {
     provide: 'WORKFLOW_EXECUTION_REPOSITORY',
-    useFactory: (dataSource: DataSource) =>
-      dataSource.getRepository(WorkflowExecution),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      return dataSource.getRepository(WorkflowExecution);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];
@@ -45,8 +62,12 @@ export const workflowExecutionProviders = [
 export const workflowExecutionTraceProviders = [
   {
     provide: 'WORKFLOW_EXECUTION_TRACE_REPOSITORY',
-    useFactory: (dataSource: DataSource) =>
-      dataSource.getRepository(WorkflowExecutionTrace),
+    useFactory: (dataSource: DataSource) => {
+      if (!dataSource) {
+        return null;
+      }
+      dataSource.getRepository(WorkflowExecutionTrace);
+    },
     inject: ['DATA_SOURCE'],
   },
 ];


### PR DESCRIPTION
This pull request includes several changes to ensure that the database providers return `null` if the `dataSource` or `configService` is not available. This helps prevent potential runtime errors due to missing dependencies.

### Improvements to error handling in database providers:

* [`src/providers/database/database.providers.ts`](diffhunk://#diff-ddd745eaba97c90b9dfbb03b600235ac8470368ae9b473f2963526e23edb4d6fR20-R22): Added a check to return `null` if the `DB_HOST` configuration is not present in the `ConfigService`.

* [`src/providers/database/providers/permission.providers.ts`](diffhunk://#diff-b373a1fbb0b66e14419a5c4d8ed36823c9f2dba7da6e7829a7e044c32be55d47L7-R25): Modified the `useFactory` methods to return `null` if the `dataSource` is not available for `Policy` and `Rule` repositories.

* [`src/providers/database/providers/service.providers.ts`](diffhunk://#diff-1f862f3d77455c0b5bdf275aeccd2f9f654179aaf73e48ad0dc825890a94e6e2L7-R51): Updated the `useFactory` methods to return `null` if the `dataSource` is not available for `Service`, `Node`, `Code`, and `ServiceUser` repositories.

* [`src/providers/database/providers/user.providers.ts`](diffhunk://#diff-c04ea6943676e110efd88da8e876b88821239c59100b9bce5775050a926b7fc8L7-R12): Adjusted the `useFactory` method to return `null` if the `dataSource` is not available for the `User` repository.

* [`src/providers/database/providers/webhook.providers.ts`](diffhunk://#diff-c4354146a9cc51d7dbaede3bda0691d690695cc9d579169a7a0b552db643779eL7-R12): Changed the `useFactory` method to return `null` if the `dataSource` is not available for the `Webhook` repository.

* [`src/providers/database/providers/workflow.providers.ts`](diffhunk://#diff-58661bc121c03c4cb763d73745e9e4772322831f947d20ac38264dfd8b1a7ac3L13-R70): Enhanced the `useFactory` methods to return `null` if the `dataSource` is not available for `Workflow`, `WorkflowNode`, `WorkflowNodeNext`, `WorkflowExecution`, and `WorkflowExecutionTrace` repositories.